### PR TITLE
Fix build failures with new CDC connector

### DIFF
--- a/cmake/FindCDC.cmake
+++ b/cmake/FindCDC.cmake
@@ -4,7 +4,7 @@
 #   - CDC_LIBRARIES (only if CDC_FOUND)
 
 # Try to find the header
-FIND_PATH(CDC_INCLUDE_DIR NAMES cdc_connector.h)
+FIND_PATH(CDC_INCLUDE_DIR NAMES cdc_connector.h PATH_SUFFIXES maxscale)
 
 # Try to find the library
 FIND_LIBRARY(CDC_LIBRARY NAMES cdc_connector)


### PR DESCRIPTION
The CDC connector API has changed in the latest 2.2 branch of MaxScale
which means that a few adjustments are needed.