### PR TITLE
MCOL-1255

### DIFF
--- a/kettle-columnstore-bulk-exporter-plugin/src/main/java/com/mariadb/columnstore/api/kettle/KettleColumnStoreBulkExporterStepDialog.java
+++ b/kettle-columnstore-bulk-exporter-plugin/src/main/java/com/mariadb/columnstore/api/kettle/KettleColumnStoreBulkExporterStepDialog.java
@@ -89,7 +89,7 @@ public class KettleColumnStoreBulkExporterStepDialog extends BaseStepDialog impl
   private CCombo wConnection;
 
   //columnstore xml connection configuration file
-  private TextVar wColumnStoreXML;
+  private Text wColumnStoreXML;
 
   private ColumnStoreDriver d;
 
@@ -312,7 +312,7 @@ public class KettleColumnStoreBulkExporterStepDialog extends BaseStepDialog impl
     fdbColumnStoreXML.right = new FormAttachment(100, 0);
     fdbColumnStoreXML.top = new FormAttachment(wConnection, margin);
     wbColumnStoreXML.setLayoutData(fdbColumnStoreXML);
-    wColumnStoreXML = new TextVar(transMeta, composite, SWT.READ_ONLY | SWT.SINGLE | SWT.LEFT | SWT.BORDER);
+    wColumnStoreXML = new Text(composite, SWT.READ_ONLY | SWT.SINGLE | SWT.LEFT | SWT.BORDER);
     props.setLook(wColumnStoreXML);
     wColumnStoreXML.addModifyListener(lsMod);
     FormData fdColumnStoreXML = new FormData();
@@ -812,3 +812,4 @@ public class KettleColumnStoreBulkExporterStepDialog extends BaseStepDialog impl
     }
   }
 }
+

--- a/kettle-columnstore-bulk-exporter-plugin/test/export-to-mariadb.ktr
+++ b/kettle-columnstore-bulk-exporter-plugin/test/export-to-mariadb.ktr
@@ -614,7 +614,7 @@
     <connection>ColumnStore JDBC</connection>
     <targetdatabase>test</targetdatabase>
     <targettable>kettle_api_columnstore</targettable>
-    <columnStoreXML />
+    <columnStoreXML></columnStoreXML>
     <numberOfMappingEntries>19</numberOfMappingEntries>
     <inputField_0_Name>uint64</inputField_0_Name>
     <targetField_0_Name>uint64</targetField_0_Name>
@@ -983,6 +983,27 @@ FROM kettle_test_data
         <item>1</item>
         <item>42424242</item>
         <item>0.01</item>
+      </line>
+      <line>
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
+        <item />
       </line>
     </data>
     <cluster_schema />


### PR DESCRIPTION
removed the ability to use variable names for setting the Columnstore.xml configuration path.