### PR TITLE
MCOL-1401 - test.sh added for continious integration of PDI plugin.

### DIFF
--- a/kettle-columnstore-bulk-exporter-plugin/.gitignore
+++ b/kettle-columnstore-bulk-exporter-plugin/.gitignore
@@ -1,2 +1,4 @@
 .gradle
 test/*.csv
+test/data-integration
+test/*.log

--- a/kettle-columnstore-bulk-exporter-plugin/README.md
+++ b/kettle-columnstore-bulk-exporter-plugin/README.md
@@ -57,7 +57,18 @@ Individual configurations can be assigned within each block.
 Information on how to change the _Columnstore.xml_ configuration file to connect to remote ColumnStore instances can be found in our  [Knowledge Base](https://mariadb.com/kb/en/library/columnstore-bulk-write-sdk/#environment-configuration).
 
 ## Testing
-To test the plugin you can execute the job _test.kjb_ from the _test_ directory. 
+All continious integration test jobs are in the _test_ directory and can be either loaded manually into kettle or be executed through
+
+```shell
+./test/test.sh
+```
+
+This script will download PDI 7, install the build plugin and MariaDB JDBC driver, and execute the tests.
+
+If it exits with error code 0, all tests passed.
+
+### test.kjb
+This job runs a basic ingestion test of all datatypes into ColumnStore and InnoDB tables and compares the results.
 
 You might have to change the JDBC configuration in _test.kjb_, _export-to-mariadb.ktr_ and _export-to-csv.ktr_ to match your ColumnStore installation. 
 

--- a/kettle-columnstore-bulk-exporter-plugin/test/test.sh
+++ b/kettle-columnstore-bulk-exporter-plugin/test/test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# testing script that downloads pdi and executes all kettle jobs (*.kjb) from the test directory
+
+set -e          #Exit as soon as any line in the bash script fails
+#set -x          #Prints each command executed (prefix with ++)
+
+pdi7zipFile="pdi-ce-7.1.0.0-12.zip"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" #get the absolute diretory of this script
+
+# download and install PDI 7
+if [ ! -d $DIR/data-integration ] ; then
+	echo "PDI installation not found"
+	if [ ! -f $DIR/$pdi7zipFile ] ; then
+		echo "PDI 7 zip file not found - initiate download"
+		curl -o $DIR/$pdi7zipFile https://svwh.dl.sourceforge.net/project/pentaho/Data%20Integration/7.1/$pdi7zipFile
+	else
+		echo "old PDI 7 zip file found - delete it and restart download"
+		rm $DIR/$pdi7zipFile
+		curl -o $DIR/$pdi7zipFile https://svwh.dl.sourceforge.net/project/pentaho/Data%20Integration/7.1/$pdi7zipFile
+	fi
+	echo "installing PDI 7 from $pdi7zipFile"
+	unzip $DIR/$pdi7zipFile -d $DIR
+	curl -o $DIR/data-integration/lib/mariadb-java-client-2.2.3.jar https://downloads.mariadb.com/Connectors/java/connector-java-2.2.3/mariadb-java-client-2.2.3.jar
+	rm $DIR/$pdi7zipFile
+fi
+
+# install the columnstore plugin
+if [ -d $DIR/data-integration/plugins/kettle-columnstore-bulk-exporter-plugin ]; then
+	echo "deleting old pdi columnstore bulk exporter plugin"
+	rm -rf $DIR/data-integration/plugins/kettle-columnstore-bulk-exporter-plugin
+fi
+echo "installing the columnstore bulk exporter plugin"
+unzip $DIR/../build/distributions/kettle-columnstore-bulk-exporter-plugin-*.zip -d $DIR/data-integration/plugins
+
+# delete old test logs
+numberOfOldLogFiles=`ls $DIR/*.log | wc -l`
+if [ $numberOfOldLogFiles -gt 0 ]; then
+	echo "deleting old test log files"
+	rm $DIR/*.log
+fi
+
+# executing tests
+for t in $( ls $DIR | grep .*\.kjb$ ); do
+	echo "executing test $t"
+	$DIR/data-integration/kitchen.sh -dir $DIR -file $DIR/$t -level Debug -logfile $DIR/$t.log
+	echo "test $t finished successfully"
+done
+echo "all tests executed successfully"


### PR DESCRIPTION
The script downloads PDI 7, and installs the build plugin + dependencies. Afterwards all defined tests from the test directory (./test/*.kjb) are executed.