### PR TITLE
Readme update + version bump

### DIFF
--- a/kettle-columnstore-bulk-exporter-plugin/README.md
+++ b/kettle-columnstore-bulk-exporter-plugin/README.md
@@ -18,9 +18,13 @@ Follow this steps to build the plugin from source.
 
 ### Requirements
 These requirements need to be installed prior building:
-* MariaDB AX Bulk Data Adapters 1.1.5 (an DEB/RPM is provided by [MariaDB](https://mariadb.com/downloads/mariadb-ax/data-adapters))
+* MariaDB AX Bulk Data Adapters 1.1.6 (an DEB/RPM is provided by [MariaDB](https://mariadb.com/downloads/mariadb-ax/data-adapters))
 * Java SDK 8 or higher
-* chrpath (sudo apt-get install chrpath || sudo yum install chrpath)
+* chrpath 
+```shell
+sudo apt-get install chrpath
+sudo yum install chrpath
+```
 
 ### Build process
 To build the plugin from source execute following commands:
@@ -71,9 +75,7 @@ You might have to change the database connection properties set in _job.paramete
 This job runs a basic ingestion test of all datatypes into ColumnStore and InnoDB tables and compares the results.
 
 ### csv-ingestion-test
-Ingests two csv files, to ColumnStore. Possible to adapt the number of ingestion loops to run in _job.parameter_.
-
-Currently only tests if the job is executed, but not if the ingestion was successful.
+Ingests two csv files into ColumnStore and checks if the count of injected rows matches the line count of the csv files. Possible to adapt the number of ingestion loops to run in _job.parameter_.
 
 ## Limitations
 The plugin currently can't handle blob datatypes and only supports multi inputs to one block if the input field names are equal for all input sources.

--- a/kettle-columnstore-bulk-exporter-plugin/build.gradle
+++ b/kettle-columnstore-bulk-exporter-plugin/build.gradle
@@ -1,7 +1,7 @@
 group 'com.mariadb.columnstore.api.kettle'
 
 if (project.property('version').equals('unspecified')){
-    version '1.1.5'
+    version '1.1.6'
 } else{
     version project.property('version')
 }


### PR DESCRIPTION
- Updated the Kettle Readme to reference the 1.1.6 data adapters
- Updated the Kettle Readme csv-ingestion test details
- Updated Kettle's gradle build file fallback version to 1.1.6 if built manually without cmake