### PR TITLE
MCOL-1392 - Timestamp csv input fix

### DIFF
--- a/kettle-columnstore-bulk-exporter-plugin/src/main/java/com/mariadb/columnstore/api/kettle/KettleColumnStoreBulkExporterStep.java
+++ b/kettle-columnstore-bulk-exporter-plugin/src/main/java/com/mariadb/columnstore/api/kettle/KettleColumnStoreBulkExporterStep.java
@@ -330,8 +330,9 @@ public class KettleColumnStoreBulkExporterStep extends BaseStep implements StepI
                     }else{
                         logDebug("Try to insert item " + i + " as Timestamp");
                         java.sql.Timestamp t;
-                        if (data.rowValueTypes.get(i).getNativeDataType(r[i]) instanceof java.sql.Timestamp){
-                            t = (java.sql.Timestamp) data.rowValueTypes.get(i).getNativeDataType(r[i]);
+                        Object nativeData = data.rowValueTypes.get(i).getNativeDataType(r[i]);
+                        if (nativeData instanceof java.sql.Timestamp){
+                            t = (java.sql.Timestamp) nativeData;
                         } else{
                             t = valueMetaTimestamp.getTimestamp(r[i]);
                         }

--- a/kettle-columnstore-bulk-exporter-plugin/src/main/java/com/mariadb/columnstore/api/kettle/KettleColumnStoreBulkExporterStep.java
+++ b/kettle-columnstore-bulk-exporter-plugin/src/main/java/com/mariadb/columnstore/api/kettle/KettleColumnStoreBulkExporterStep.java
@@ -329,7 +329,12 @@ public class KettleColumnStoreBulkExporterStep extends BaseStep implements StepI
                         }
                     }else{
                         logDebug("Try to insert item " + i + " as Timestamp");
-                        java.sql.Timestamp t = valueMetaTimestamp.getTimestamp(r[i]);
+                        java.sql.Timestamp t;
+                        if (data.rowValueTypes.get(i).getNativeDataType(r[i]) instanceof java.sql.Timestamp){
+                            t = (java.sql.Timestamp) data.rowValueTypes.get(i).getNativeDataType(r[i]);
+                        } else{
+                            t = valueMetaTimestamp.getTimestamp(r[i]);
+                        }
                         logDebug("Value to insert: " + t.toString());
                         data.b.setColumn(c, t.toString());
                         logDebug("Inserted item " + i + " as Timestamp");


### PR DESCRIPTION
Fixes the java class cast exception if csv input files contain timestamps.

Regression suite run successfully on Windows 10 and CentOS 7.

Manually tested the csv input of Timestamp data on Windows 10 and PDI 7.1