### PR TITLE
Feature* Kafka DA now supports complex schemas.

### DIFF
--- a/cmake/FindAvro.cmake
+++ b/cmake/FindAvro.cmake
@@ -10,5 +10,7 @@ find_library(AVRO_LIBRARIES libavro.a)
 
 if (AVRO_INCLUDE_DIRS AND AVRO_LIBRARIES)
   message(STATUS "Found Avro C libraries: ${AVRO_LIBRARIES}")
+  set(AVRO_LIBRARIES avro)
+  message(STATUS "Found Avro C libraries.")
   set(AVRO_FOUND TRUE)
 endif()

--- a/cmake/FindAvro.cmake
+++ b/cmake/FindAvro.cmake
@@ -10,7 +10,5 @@ find_library(AVRO_LIBRARIES libavro.a)
 
 if (AVRO_INCLUDE_DIRS AND AVRO_LIBRARIES)
   message(STATUS "Found Avro C libraries: ${AVRO_LIBRARIES}")
-  set(AVRO_LIBRARIES avro)
-  message(STATUS "Found Avro C libraries.")
   set(AVRO_FOUND TRUE)
 endif()

--- a/kafka-avro-adapter/src/common.cpp
+++ b/kafka-avro-adapter/src/common.cpp
@@ -173,6 +173,7 @@ Options::Options(std::string arg_topic, std::string arg_database, std::string ar
     from_json(opts, "config", config);
     from_json(opts, "max_rows", max_rows);
     from_json(opts, "max_time", max_time);
+    from_json(opts, "debug", debug);
 }
 
 template <> void Closer<json_t*>::close(json_t* t)

--- a/kafka-avro-adapter/src/common.h
+++ b/kafka-avro-adapter/src/common.h
@@ -74,6 +74,7 @@ struct Options
     std::string config = "Columnstore.xml";
     uint32_t    max_rows = 1000;
     Seconds     max_time = Seconds(5);
+    std::string debug;
 
     /**
      * Default options

--- a/kafka-avro-adapter/src/controller.cpp
+++ b/kafka-avro-adapter/src/controller.cpp
@@ -51,11 +51,11 @@ void Controller::run()
                 m_last_flush = Clock::now();
             }
         }
-        catch (AdapterError e)
+        catch (AdapterError &e)
         {
            logger() << "Adapter Exception: " << e.what() << std::endl;
         }
-        catch (mcsapi::ColumnStoreError e)
+        catch (mcsapi::ColumnStoreError &e)
         {
            logger() << "ColumnStore Exception: " << e.what() << std::endl;
         }

--- a/kafka-avro-adapter/src/cs_producer.cpp
+++ b/kafka-avro-adapter/src/cs_producer.cpp
@@ -18,140 +18,177 @@
 #include "common.h"
 
 void CSProducer::processAvroType(BulkInsert& insert, avro_value_t* value)
-
 {
-    auto table = m_driver.getSystemCatalog().getTable(m_options.database, m_options.table);
+    mcsapi::ColumnStoreSystemCatalogTable table = m_driver.getSystemCatalog().getTable(m_options.database, m_options.table);
+    processAvroType_(insert, value, table);
+    insert->writeRow();
+}
 
-    assert(avro_value_get_type(value) == AVRO_RECORD);
-    size_t n_fields = 0;
-    avro_value_get_size(value, &n_fields);
-
-    for (size_t i = 0; i < n_fields; i++)
+void CSProducer::processAvroType_(BulkInsert& insert,
+    avro_value_t* value,
+    mcsapi::ColumnStoreSystemCatalogTable& table)
+{
+    // This won't work for nested UNIONs or UNIONS with base types
+    if (avro_value_get_type(value) == AVRO_RECORD)
     {
-        avro_value_t field;
-        avro_value_get_by_index(value, i, &field, NULL);
-        const char* name = avro_schema_record_field_name(avro_value_get_schema(value), i);
-        int table_idx = table.getColumn(name).getPosition();
+        size_t n_fields = 0;
+        avro_value_get_size(value, &n_fields);
 
-        switch (avro_value_get_type(&field))
+        for (size_t i = 0; i < n_fields; i++)
         {
-            case AVRO_STRING:
-            {
-                const char* s;
-                size_t len;
-                int r = avro_value_get_string(&field, &s, &len);
-                assert(r == 0);
-                std::string str = std::string(s, len);
-                logger() << "STRING: " << str << std::endl;
-                insert->setColumn(table_idx, str);
-                break;
-            }
-            case AVRO_BYTES:
-            {
-                const void* s;
-                size_t len;
-                int r = avro_value_get_bytes(&field, &s, &len);
-                assert(r == 0);
-                insert->setColumn(table_idx, std::string((char*)s, len));
+            avro_value_t field;
+            avro_value_get_by_index(value, i, &field, NULL);
+            const char* name = avro_schema_record_field_name(avro_value_get_schema(value), i);
+            int table_idx = table.getColumn(name).getPosition();
 
-                break;
-            }
-            case AVRO_INT32:
+            if ( avro_value_get_type(&field) == AVRO_UNION )
             {
-                int32_t out;
-                int r = avro_value_get_int(&field, &out);
-                assert(r == 0);
-                insert->setColumn(table_idx, out);
-                break;
+                int disc;
+                avro_value_get_discriminant(&field, &disc);
+         
+                if ( disc > 0 )
+                {
+                    avro_value_t union_value;
+                    avro_value_set_branch(&field, disc, &union_value);
+                    if( avro_value_get_type(&union_value) == AVRO_RECORD )
+                    {
+                        char* json_string;
+                        processAvroType_(insert, &union_value, table);
+                        // Put the raw JSON for a RECORD just in case
+                        avro_value_to_json(&union_value, 1, &json_string);
+                        std::string jsonString = std::string(json_string);
+                        insert->setColumn(table_idx, jsonString);
+                        free(json_string);
+                    }
+                    else
+                        processAvroNonRec(insert, &union_value, table, 
+                            table_idx);
+                }
+                else if ( disc == 0 )
+                {
+                    insert->setNull(table_idx);
+                }
             }
-            case AVRO_INT64:
+            else if ( avro_value_get_type(&field) == AVRO_RECORD )
             {
-                int64_t out;
-                int r = avro_value_get_long(&field, &out);
-                assert(r == 0);
-                insert->setColumn(table_idx, out);
-                break;
+                processAvroType_(insert, &field, table);
             }
-            case AVRO_FLOAT:
-            {
-                float out;
-                int r = avro_value_get_float(&field, &out);
-                assert(r == 0);
-                insert->setColumn(table_idx, out);
-                break;
-            }
-            case AVRO_DOUBLE:
-            {
-                double out;
-                int r = avro_value_get_double(&field, &out);
-                assert(r == 0);
-                insert->setColumn(table_idx, out);
-                break;
-            }
-            case AVRO_BOOLEAN:
-            {
-                int out = 0;
-                int r = avro_value_get_boolean(&field, &out);
-                assert(r == 0);
-                insert->setColumn(table_idx, (bool)out);
-                break;
-            }
-            case AVRO_NULL:
-            {
-                insert->setNull(table_idx);
-                break;
-            }
-            case AVRO_ENUM:
-            {
-                int out = 0;
-                int r = avro_value_get_enum(&field, &out);
-                assert(r == 0);
-                insert->setColumn(table_idx, out);
-                break;
-            }
-            case AVRO_FIXED:
-            {
-                const void* s;
-                size_t len;
-                int r = avro_value_get_fixed(&field, &s, &len);
-                assert(r == 0);
-                insert->setColumn(table_idx, std::string((char*)s, len));
-                break;
-            }
-            case AVRO_RECORD:
-            {
-                logger() << "Unsupported type: RECORD" << std::endl;
-                break;
-            }
-            case AVRO_MAP:
-            {
-                logger() << "Unsupported type: MAP" << std::endl;
-                break;
-            }
-            case AVRO_ARRAY:
-            {
-                logger() << "Unsupported type: ARRAY" << std::endl;
-                break;
-            }
-            case AVRO_UNION:
-            {
-                logger() << "Unsupported type: UNION" << std::endl;
-                break;
-            }
-            case AVRO_LINK:
-            {
-                logger() << "Unsupported type: LINK" << std::endl;
-                break;
-            }
-
-            default:
-                logger() << "Unsupported type: LINK" << std::endl;
-                assert(false);
-                break;
+            else
+                processAvroNonRec(insert, &field, table, table_idx);
         }
     }
+}
 
-    insert->writeRow();
+void CSProducer::processAvroNonRec(BulkInsert& insert, 
+    avro_value_t* field, 
+    mcsapi::ColumnStoreSystemCatalogTable& table,
+    int table_idx )
+{
+    switch (avro_value_get_type(field))
+    {
+        case AVRO_STRING:
+        {
+            const char* s;
+            size_t len;
+            int r = avro_value_get_string(field, &s, &len);
+            assert(r == 0);
+            std::string str = std::string(s, len);
+            insert->setColumn(table_idx, str);
+            break;
+        }
+        case AVRO_BYTES:
+        {
+            const void* s;
+            size_t len;
+            int r = avro_value_get_bytes(field, &s, &len);
+            assert(r == 0);
+            insert->setColumn(table_idx, std::string((char*)s, len));
+
+            break;
+        }
+        case AVRO_INT32:
+        {
+            int32_t out;
+            int r = avro_value_get_int(field, &out);
+            assert(r == 0);
+            insert->setColumn(table_idx, out);
+            break;
+        }
+        case AVRO_INT64:
+        {
+            int64_t out;
+            int r = avro_value_get_long(field, &out);
+            assert(r == 0);
+            insert->setColumn(table_idx, out);
+            break;
+        }
+        case AVRO_FLOAT:
+        {
+            float out;
+            int r = avro_value_get_float(field, &out);
+            assert(r == 0);
+            insert->setColumn(table_idx, out);
+            break;
+        }
+        case AVRO_DOUBLE:
+        {
+            double out;
+            int r = avro_value_get_double(field, &out);
+            assert(r == 0);
+            insert->setColumn(table_idx, out);
+            break;
+        }
+        case AVRO_BOOLEAN:
+        {
+            int out = 0;
+            int r = avro_value_get_boolean(field, &out);
+            assert(r == 0);
+            insert->setColumn(table_idx, (bool)out);
+            break;
+        }
+        case AVRO_NULL:
+        {
+            insert->setNull(table_idx);
+            break;
+        }
+        case AVRO_ENUM:
+        {
+            int out = 0;
+            int r = avro_value_get_enum(field, &out);
+            assert(r == 0);
+            insert->setColumn(table_idx, out);
+            break;
+        }
+        case AVRO_FIXED:
+        {
+            const void* s;
+            size_t len;
+            int r = avro_value_get_fixed(field, &s, &len);
+            assert(r == 0);
+            insert->setColumn(table_idx, std::string((char*)s, len));
+            break;
+        }
+        case AVRO_MAP:
+        {
+            logger() << "Unsupported type: MAP" << std::endl;
+            break;
+        }
+        case AVRO_ARRAY:
+        {
+            logger() << "Unsupported type: ARRAY" << std::endl;
+            break;
+        }
+        case AVRO_LINK:
+        {
+            logger() << "Unsupported type: LINK" << std::endl;
+            break;
+        }
+
+        default:
+            logger() << "Unsupported type: LINK" << std::endl;
+            assert(false);
+            break;
+    }
 }
 
 CSProducer::CSProducer(const Options& options):

--- a/kafka-avro-adapter/src/cs_producer.h
+++ b/kafka-avro-adapter/src/cs_producer.h
@@ -36,7 +36,7 @@ private:
     mcsapi::ColumnStoreDriver m_driver;
 
     void processAvroType(BulkInsert& insert, avro_value_t* value);
-    void processAvroType_(BulkInsert& insert, avro_value_t* value,
+    void processAvroType(BulkInsert& insert, avro_value_t* value,
         mcsapi::ColumnStoreSystemCatalogTable& table);
     void processAvroNonRec(BulkInsert& insert, avro_value_t* value,
     mcsapi::ColumnStoreSystemCatalogTable& table, int table_idx);

--- a/kafka-avro-adapter/src/cs_producer.h
+++ b/kafka-avro-adapter/src/cs_producer.h
@@ -18,6 +18,8 @@
 
 #include <libmcsapi/mcsapi.h>
 
+#include <string.h>
+
 typedef std::unique_ptr<mcsapi::ColumnStoreBulkInsert> BulkInsert;
 
 class CSProducer
@@ -34,4 +36,8 @@ private:
     mcsapi::ColumnStoreDriver m_driver;
 
     void processAvroType(BulkInsert& insert, avro_value_t* value);
+    void processAvroType_(BulkInsert& insert, avro_value_t* value,
+        mcsapi::ColumnStoreSystemCatalogTable& table);
+    void processAvroNonRec(BulkInsert& insert, avro_value_t* value,
+    mcsapi::ColumnStoreSystemCatalogTable& table, int table_idx);
 };

--- a/kafka-avro-adapter/src/kafka_consumer.cpp
+++ b/kafka-avro-adapter/src/kafka_consumer.cpp
@@ -142,6 +142,13 @@ KafkaConsumer::KafkaConsumer(const Options& options):
     std::string errstr;
     conf->set("metadata.broker.list", m_options.broker, errstr);
     conf->set("group.id", m_options.group, errstr);
+
+    if (!m_options.debug.empty()) {
+        if (conf->set("debug", m_options.debug, errstr) != RdKafka::Conf::CONF_OK) {
+        throw AdapterError("Failed to set an librdkafka option: " + errstr);
+        }
+    }
+
     m_consumer.reset(RdKafka::KafkaConsumer::create(conf, errstr));
 
     if (!m_consumer) {

--- a/kafka-avro-adapter/src/kafka_consumer.cpp
+++ b/kafka-avro-adapter/src/kafka_consumer.cpp
@@ -143,9 +143,11 @@ KafkaConsumer::KafkaConsumer(const Options& options):
     conf->set("metadata.broker.list", m_options.broker, errstr);
     conf->set("group.id", m_options.group, errstr);
 
-    if (!m_options.debug.empty()) {
-        if (conf->set("debug", m_options.debug, errstr) != RdKafka::Conf::CONF_OK) {
-        throw AdapterError("Failed to set an librdkafka option: " + errstr);
+    if (!m_options.debug.empty()) 
+    {
+        if (conf->set("debug", m_options.debug, errstr) != RdKafka::Conf::CONF_OK) 
+        {
+            throw AdapterError("Failed to set an librdkafka option: " + errstr);
         }
     }
 

--- a/kafka-avro-adapter/src/kafka_to_avro.cpp
+++ b/kafka-avro-adapter/src/kafka_to_avro.cpp
@@ -61,8 +61,7 @@ int main(int argc, char* argv[])
         case 'c':
             config = optarg;
             break;
-
-            default:
+        default:
             usage();
             exit(1);
             break;

--- a/kafka-avro-adapter/src/kafka_to_avro.cpp
+++ b/kafka-avro-adapter/src/kafka_to_avro.cpp
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
             ctrl->stop();
         }
     }
-    catch (std::runtime_error e)
+    catch (std::runtime_error &e)
     {
         logger() << e.what() << std::endl;
     }


### PR DESCRIPTION
The first commit add debug flag for librdkafka for troubleshooting purposes.
The last commit allows to stream changes from Postgres into Columnstore using Debezium. Debezium packet schema contains complex types so Kafka event processing was refactored.

