### PR TITLE
Fix string encoding

### DIFF
--- a/kafka-avro-adapter/src/cs_producer.cpp
+++ b/kafka-avro-adapter/src/cs_producer.cpp
@@ -112,7 +112,8 @@ void CSProducer::processAvroNonRec(BulkInsert& insert,
             size_t len;
             int r = avro_value_get_string(field, &s, &len);
             assert(r == 0);
-            std::string str = std::string(s, len);
+            assert(len > 0);
+            std::string str = std::string(s, len - 1);
             insert->setColumn(table_idx, str);
             break;
         }

--- a/maxscale-cdc-adapter/src/context.hh
+++ b/maxscale-cdc-adapter/src/context.hh
@@ -70,7 +70,14 @@ struct Context
     {
         if (bulk)
         {
-            bulk->rollback();
+            try
+            {
+                bulk->rollback();
+            }
+            catch (...)
+            {
+                // Ignore exceptions, there's not much we can do at this point
+            }
         }
     }
 };


### PR DESCRIPTION
The strings returned by the Avro C API include the null terminator in the
string length.